### PR TITLE
Templates: added proper comments

### DIFF
--- a/templates/template_keys.py
+++ b/templates/template_keys.py
@@ -12,4 +12,5 @@ API keys and tokens for the bot.
 ---
 """
 
+# The Discord bot token
 discord_token = ""

--- a/templates/template_options.py
+++ b/templates/template_options.py
@@ -12,6 +12,15 @@ Settings and options for the bot.
 ---
 """
 
+# The prefix for the bot (str). Define a list of stings for multiple prefixes.
+# ie: `["?", "!", "pls "]`
 prefix = "?"
+
+# Whether the bot should print full stacktraces for normal exceptions: `True`,
+# or be nice and only print small messages: `False` (the default).
 debug = False
-owners_uids = ()
+
+# A tuple of user IDs that should be considered "bot owners".
+# * Those users will have full control over the bot.
+# ! This MUST be a tuple of integers. Single element tuple: `(123,)`
+owners_uids = (200102491231092736,)


### PR DESCRIPTION
- Added a default value for 'owners_uids'
- Added notes on proper types where applicable.
- That's pretty much it

Fixes #26

Bonus: already clear comment syntax also gets coloured in some editors:  
![image](https://user-images.githubusercontent.com/5877043/66320410-c6fe6f00-e8ec-11e9-810e-1d8ab96b73c9.png)
