### PR TITLE
add canadian callsign info, improve the prefix info data system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]
+### Added
+- Canadian prefix info to the `?prefixes` command.
 
 
 ## [2.3.2] - 2020-07-22

--- a/common.py
+++ b/common.py
@@ -70,6 +70,16 @@ paths = SimpleNamespace(
 
 # --- Classes ---
 
+
+class CallsignInfoData:
+    """Represents a country's callsign info"""
+    def __init__(self, data: list):
+        self.title: str = data[0]
+        self.desc: str = data[1]
+        self.calls: str = data[2]
+        self.emoji: str = data[3]
+
+
 class ImageMetadata:
     """Represents the metadata of a single image."""
     def __init__(self, metadata: list):

--- a/exts/ham.py
+++ b/exts/ham.py
@@ -21,6 +21,7 @@ from resources import qcodes
 class HamCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.pfxs = callsign_info.options
 
     @commands.command(name="qcode", aliases=["q"], category=cmn.cat.ref)
     async def _qcode_lookup(self, ctx: commands.Context, qcode: str):
@@ -64,22 +65,26 @@ class HamCog(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(name="prefixes", aliases=["vanity", "pfx", "vanities", "prefix"], category=cmn.cat.ref)
-    async def _vanity_prefixes(self, ctx: commands.Context, country: str = None):
+    async def _vanity_prefixes(self, ctx: commands.Context, country: str = ""):
         """Lists valid callsign prefixes for different countries."""
-        if country is None:
-            await ctx.send_help(ctx.command)
-            return
+        country = country.lower()
         embed = cmn.embed_factory(ctx)
-        if country.lower() not in callsign_info.options:
-            embed.title = f"{country} not found!"
-            embed.description = f"Valid countries: {', '.join(callsign_info.options.keys())}"
+        if country not in self.pfxs:
+            desc = "Possible arguments are:\n"
+            for key, val in self.pfxs.items():
+                desc += f"`{key}`: {val.title}{('  ' + val.emoji if val.emoji else '')}\n"
+            embed.title = f"{country} Not Found!"
+            embed.description = desc
             embed.colour = cmn.colours.bad
+            await ctx.send(embed=embed)
+            return
         else:
-            embed.title = callsign_info.options[country.lower()][0]
-            embed.description = callsign_info.options[country.lower()][1]
+            data = self.pfxs[country]
+            embed.title = data.title + ("  " + data.emoji if data.emoji else "")
+            embed.description = data.desc
             embed.colour = cmn.colours.good
 
-            for name, val in callsign_info.options[country.lower()][2].items():
+            for name, val in data.calls.items():
                 embed.add_field(name=name, value=val, inline=False)
         await ctx.send(embed=embed)
 

--- a/resources/callsign_info.py
+++ b/resources/callsign_info.py
@@ -1,5 +1,5 @@
 """
-Information about callsigns for the vanity prefixes command in hamcog.
+Information about callsigns for the prefixes command in hamcog.
 ---
 Copyright (C) 2019-2020 Abigail Gold, 0x5c
 
@@ -7,49 +7,12 @@ This file is part of discord-qrmbot and is released under the terms of
 the GNU General Public License, version 2.
 """
 
+from .callsigninfos import (us, ca)
+from common import CallsignInfoData
 
-us_calls_title = "Valid US Vanity Callsigns"
-us_calls_desc = ("#x# is the number of letters in the prefix and suffix of a callsign. "
-                 "E.g., WY4RC would be a 2x2 callsign, with prefix WY and suffix RC.")
-us_calls = {
-                "**Group A** (Extra Only)": ("**Any:** K, N, W (1x2)\n"
-                                             "    AA-AL, KA-KZ, NA-NZ, WA-WZ (2x1)\n"
-                                             "    AA-AL (2x2)\n"
-                                             "*Except*\n"
-                                             "**Alaska:** AL, KL, NL, WL (2x1)\n"
-                                             "**Caribbean:** KP, NP, WP (2x1)\n"
-                                             "**Pacific:** AH, KH, NH, WH (2x1)"),
-                "**Group B** (Advanced and Extra Only)": ("**Any:** KA-KZ, NA-NZ, WA-WZ (2x2)\n"
-                                                          "*Except*\n"
-                                                          "**Alaska:** AL (2x2)\n"
-                                                          "**Caribbean:** KP (2x2)\n"
-                                                          "**Pacific:** AH (2x2)"),
-                "**Group C** (Technician, General, Advanced, Extra Only)": ("**Any Region:** K, N, W (1x3)\n"
-                                                                            "*Except*\n"
-                                                                            "**Alaska:** KL, NL, WL (2x2)\n"
-                                                                            "**Caribbean:** NP, WP (2x2)\n"
-                                                                            "**Pacific:** KH, NH, WH (2x2)"),
-                "**Group D** (Any License Class)": ("**Any Region:** KA-KZ, WA-WZ (2x3)\n"
-                                                    "*Except*\n"
-                                                    "**Alaska:** KL, WL (2x3)\n"
-                                                    "**Caribbean:** KP, WP (2x3)\n"
-                                                    "**Pacific:** KH, WH (2x3)"),
-                "**Unavailable**": ("- KA2AA-KA9ZZ: US Army in Japan\n"
-                                    "- KC4AAA-KC4AAF: NSF in Antartica\n"
-                                    "- KC4USA-KC4USZ: US Navy in Antartica\n"
-                                    "- KG4AA-KG4ZZ: US Navy in Guantanamo Bay\n"
-                                    "- KL9KAA-KL9KHZ: US military in Korea\n"
-                                    "- KC6AA-KC6ZZ: Former US (Eastern and Western Caroline Islands), "
-                                    "now Federated States of Micronesia (V6) and Republic of Palau (T8)\n"
-                                    "- KX6AA-KX6ZZ: Former US (Marshall Islands), "
-                                    "now Republic of the Marshall Islands (V73)\n"
-                                    "- Any suffix SOS or QRA-QUZ\n"
-                                    "- Any 2x3 with X as the first suffix letter\n"
-                                    "- Any 2x3 with AF, KF, NF, or WF prefix and suffix EMA: FEMA\n"
-                                    "- Any 2x3 with AA-AL, NA-NZ, WC, WK, WM, WR, or WT prefix: \"Group X\"\n"
-                                    "- Any 2x1, 2x2, or 2x3 with KP, NP, WP prefix and 0, 6, 7, 8, 9 number\n"
-                                    "- Any 1x1 callsign: Special Event")
-           }
 
 # format: country: (title, description, text)
-options = {"us": (us_calls_title, us_calls_desc, us_calls)}
+options = {
+    "us": CallsignInfoData([us.title, us.desc, us.calls, us.emoji]),
+    "ca": CallsignInfoData([ca.title, ca.desc, ca.calls, ca.emoji]),
+}

--- a/resources/callsigninfos/__init__.py
+++ b/resources/callsigninfos/__init__.py
@@ -1,0 +1,3 @@
+"""
+Callsign info for various countries
+"""

--- a/resources/callsigninfos/ca.py
+++ b/resources/callsigninfos/ca.py
@@ -1,0 +1,47 @@
+"""
+Information about callsigns for the CA prefixes command in hamcog.
+---
+Copyright (C) 2019-2020 Abigail Gold, 0x5c
+
+This file is part of discord-qrmbot and is released under the terms of
+the GNU General Public License, version 2.
+"""
+
+
+title = "Canadian Callsign Rules"
+emoji = "🇨🇦"
+desc = ("Canadian operators are limited to callsigns with the prefixes of their address' province/territory. "
+        "Initially, operators can choose a callsign with a 3-letter suffix. "
+        "Later on, they can apply to change or for additional callsigns. "
+        "Operators can only hold one 2-letter suffix callsign, but many 3-letter suffix callsigns. "
+        "If the number of 2-letter suffix callsigns exceeds 80% of the total available, "
+        "operators can only choose a 2-letter suffix after holding a license for 5 years. "
+        "If the operator is a family member of a deceased operator, they are not bound by this restriction. "
+        "Data from [ISED Canada (RIC-9)](https://www.ic.gc.ca/eic/site/smt-gst.nsf/eng/sf02102.html).")
+calls = {
+    "Provinces": (
+        "**Nova Scotia:** VE1 and VA1\n"
+        "**Québec:** VE2 and VA2\n"
+        "**Ontario:** VE3 and VA3\n"
+        "**Manitoba:** VE4 and VA4\n"
+        "**Saskatchewan:** VE5 and VA5\n"
+        "**Alberta:** VE6 and VA6\n"
+        "**British Columbia:** VE7 and VA7\n"
+        "**New Brunswick:** VE9\n"
+        "**Newfoundland:** VO1\n"
+        "**Labrador:** VO2\n"
+        "**Prince Edward Island:** VY2\n"
+    ),
+    "Territories": (
+        "**Northwest Territories:** VE8\n"
+        "**Nunavut:** VY0\n"
+        "**Yukon:** VY1\n"
+    ),
+    "Other": (
+        "**International Waters:** VE0\n"
+        "**Government of Canada:** VY9\n"
+        "**Sable Island:** CY0\n"
+        "**St-Paul Island:** CY9\n"
+    ),
+    "Special Event": "Various prefixes in the ranges: CF-CK, CY-CZ, VA-VG, VO, VX-VY, XJ-XO"
+}

--- a/resources/callsigninfos/us.py
+++ b/resources/callsigninfos/us.py
@@ -1,0 +1,53 @@
+"""
+Information about callsigns for the US prefixes command in hamcog.
+---
+Copyright (C) 2019-2020 Abigail Gold, 0x5c
+
+This file is part of discord-qrmbot and is released under the terms of
+the GNU General Public License, version 2.
+"""
+
+
+title = "US Callsign Rules"
+emoji = "🇺🇸"
+desc = ("#x# is the number of letters in the prefix and suffix of a callsign. "
+        "E.g., WY4RC would be a 2x2 callsign, with prefix WY and suffix RC.")
+calls = {
+    "**Group A** (Extra Only)": ("**Any:** K, N, W (1x2)\n"
+                                 "    AA-AL, KA-KZ, NA-NZ, WA-WZ (2x1)\n"
+                                 "    AA-AL (2x2)\n"
+                                 "*Except*\n"
+                                 "**Alaska:** AL, KL, NL, WL (2x1)\n"
+                                 "**Caribbean:** KP, NP, WP (2x1)\n"
+                                 "**Pacific:** AH, KH, NH, WH (2x1)"),
+    "**Group B** (Advanced and Extra Only)": ("**Any:** KA-KZ, NA-NZ, WA-WZ (2x2)\n"
+                                              "*Except*\n"
+                                              "**Alaska:** AL (2x2)\n"
+                                              "**Caribbean:** KP (2x2)\n"
+                                              "**Pacific:** AH (2x2)"),
+    "**Group C** (Technician, General, Advanced, Extra Only)": ("**Any Region:** K, N, W (1x3)\n"
+                                                                "*Except*\n"
+                                                                "**Alaska:** KL, NL, WL (2x2)\n"
+                                                                "**Caribbean:** NP, WP (2x2)\n"
+                                                                "**Pacific:** KH, NH, WH (2x2)"),
+    "**Group D** (Any License Class)": ("**Any Region:** KA-KZ, WA-WZ (2x3)\n"
+                                        "*Except*\n"
+                                        "**Alaska:** KL, WL (2x3)\n"
+                                        "**Caribbean:** KP, WP (2x3)\n"
+                                        "**Pacific:** KH, WH (2x3)"),
+    "**Unavailable**": ("- KA2AA-KA9ZZ: US Army in Japan\n"
+                        "- KC4AAA-KC4AAF: NSF in Antartica\n"
+                        "- KC4USA-KC4USZ: US Navy in Antartica\n"
+                        "- KG4AA-KG4ZZ: US Navy in Guantanamo Bay\n"
+                        "- KL9KAA-KL9KHZ: US military in Korea\n"
+                        "- KC6AA-KC6ZZ: Former US (Eastern and Western Caroline Islands), "
+                        "now Federated States of Micronesia (V6) and Republic of Palau (T8)\n"
+                        "- KX6AA-KX6ZZ: Former US (Marshall Islands), "
+                        "now Republic of the Marshall Islands (V73)\n"
+                        "- Any suffix SOS or QRA-QUZ\n"
+                        "- Any 2x3 with X as the first suffix letter\n"
+                        "- Any 2x3 with AF, KF, NF, or WF prefix and suffix EMA: FEMA\n"
+                        "- Any 2x3 with AA-AL, NA-NZ, WC, WK, WM, WR, or WT prefix: \"Group X\"\n"
+                        "- Any 2x1, 2x2, or 2x3 with KP, NP, WP prefix and 0, 6, 7, 8, 9 number\n"
+                        "- Any 1x1 callsign: Special Event")
+}


### PR DESCRIPTION
fixes #243

The prefix command now produces similar output to map and bandplan on error, too.

## Output example

![image](https://user-images.githubusercontent.com/5366828/94099029-f35e1480-fdf7-11ea-9ec7-6c02eca57a48.png)

![image](https://user-images.githubusercontent.com/5366828/94098944-b98d0e00-fdf7-11ea-98f5-c6cf46925005.png)
