### PR TITLE
move CallsignInfoData to resources/callsign_info

### DIFF
--- a/common.py
+++ b/common.py
@@ -72,15 +72,6 @@ paths = SimpleNamespace(
 # --- Classes ---
 
 
-class CallsignInfoData:
-    """Represents a country's callsign info"""
-    def __init__(self, data: list):
-        self.title: str = data[0]
-        self.desc: str = data[1]
-        self.calls: str = data[2]
-        self.emoji: str = data[3]
-
-
 class ImageMetadata:
     """Represents the metadata of a single image."""
     def __init__(self, metadata: list):

--- a/resources/callsign_info.py
+++ b/resources/callsign_info.py
@@ -7,12 +7,22 @@ This file is part of discord-qrmbot and is released under the terms of
 the GNU General Public License, version 2.
 """
 
+
+from dataclasses import dataclass
+
 from .callsigninfos import (us, ca)
-from common import CallsignInfoData
 
 
-# format: country: (title, description, text)
+@dataclass
+class CallsignInfoData:
+    """Represents a country's callsign info"""
+    title: str = ""
+    desc: str = ""
+    calls: str = ""
+    emoji: str = ""
+
+
 options = {
-    "us": CallsignInfoData([us.title, us.desc, us.calls, us.emoji]),
-    "ca": CallsignInfoData([ca.title, ca.desc, ca.calls, ca.emoji]),
+    "us": CallsignInfoData(us.title, us.desc, us.calls, us.emoji),
+    "ca": CallsignInfoData(ca.title, ca.desc, ca.calls, ca.emoji),
 }


### PR DESCRIPTION
### Description

- Move `CallsignInfoData` from `common.py` to the only place it's used, `resources/callsign_info.py`

Fixes #255 

### Type of change

- Other: small refactor

### How has this been tested?

I ran the bot and tested the affected command.

### Checklist

- [x] Issue exists for PR
- [x] Code reviewed by the author
- [x] Code documented (comments or other documentation)
- [x] Changes tested
- [x] `flake8` passes
- [x] ~~`CHANGELOG.md` updated~~ (not needed for this change)
- [x] Informative commit messages
- [x] Descriptive PR title
