### PR TITLE
fixed qsl/lotw status being incorrectly shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]
+### Fixed
+- eQSL, paper QSL, and Logbook of the World status in `?qrz` sometimes being shown incorrectly.
 
 
 ## [2.4.1] - 2020-10-06

--- a/exts/qrz.py
+++ b/exts/qrz.py
@@ -18,6 +18,8 @@ from discord.ext import commands, tasks
 import common as cmn
 
 import data.keys as keys
+import pprint
+pp = pprint.PrettyPrinter(indent=4)
 
 
 class QRZCog(commands.Cog):
@@ -66,6 +68,7 @@ class QRZCog(commands.Cog):
 
             resp_xml_data = resp_xml.xpath("/x:QRZDatabase/x:Callsign", namespaces={"x": "http://xmldata.qrz.com"})
             resp_data = {el.tag.split("}")[1]: el.text for el in resp_xml_data[0].getiterator()}
+            pp.pprint(resp_data)
 
             embed = cmn.embed_factory(ctx)
             embed.title = f"QRZ Data for {resp_data['call']}"
@@ -146,15 +149,15 @@ def qrz_process_info(data: dict):
     if address == "":
         address = None
     if "eqsl" in data:
-        eqsl = "Yes" if data["eqsl"] == 1 else "No"
+        eqsl = "Yes" if data["eqsl"] == "1" else "No"
     else:
         eqsl = "Unknown"
     if "mqsl" in data:
-        mqsl = "Yes" if data["mqsl"] == 1 else "No"
+        mqsl = "Yes" if data["mqsl"] == "1" else "No"
     else:
         mqsl = "Unknown"
     if "lotw" in data:
-        lotw = "Yes" if data["lotw"] == 1 else "No"
+        lotw = "Yes" if data["lotw"] == "1" else "No"
     else:
         lotw = "Unknown"
 

--- a/exts/qrz.py
+++ b/exts/qrz.py
@@ -18,8 +18,6 @@ from discord.ext import commands, tasks
 import common as cmn
 
 import data.keys as keys
-import pprint
-pp = pprint.PrettyPrinter(indent=4)
 
 
 class QRZCog(commands.Cog):
@@ -68,7 +66,6 @@ class QRZCog(commands.Cog):
 
             resp_xml_data = resp_xml.xpath("/x:QRZDatabase/x:Callsign", namespaces={"x": "http://xmldata.qrz.com"})
             resp_data = {el.tag.split("}")[1]: el.text for el in resp_xml_data[0].getiterator()}
-            pp.pprint(resp_data)
 
             embed = cmn.embed_factory(ctx)
             embed.title = f"QRZ Data for {resp_data['call']}"


### PR DESCRIPTION
### Description

<!-- Describe the changes you made here. -->
fixed qsl/lotw status being incorrectly shown

Fixes #277 
<!-- If this fixes multiple issues, add more "Fixes #..." lines as needed -->

### Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix <!-- non-breaking change which fixes an issue -->

### How has this been tested?

<!-- Describe the procedure used for verifying your changes here. -->
Checked that those qrz fields no longer always are "no" or "unknown"

### Checklist

- [x] Issue exists for PR
- [x] Code reviewed by the author
- [x] Code documented (comments or other documentation)
- [x] Changes tested
- [x] All tests pass (see [`DEVELOPING.md`][0], if it exists)
- [x] [`CHANGELOG.md`][1] updated if needed
- [x] Informative commit messages
- [x] Descriptive PR title

[0]: /DEVELOPING.md
[1]: /CHANGELOG.md
