### PR TITLE
Moved paths to pathlib

### DIFF
--- a/exts/fun.py
+++ b/exts/fun.py
@@ -19,7 +19,7 @@ import common as cmn
 class FunCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        with open("resources/words") as words_file:
+        with open(cmn.paths.resources / "words") as words_file:
             self.words = words_file.read().lower().splitlines()
 
     @commands.command(name="xkcd", aliases=["x"], category=cmn.cat.fun)

--- a/exts/lookup.py
+++ b/exts/lookup.py
@@ -9,6 +9,7 @@ the GNU General Public License, version 2.
 
 
 import threading
+from pathlib import Path
 
 from ctyparser import BigCty
 
@@ -17,11 +18,14 @@ from discord.ext import commands, tasks
 import common as cmn
 
 
+cty_path = Path("./data/cty.json")
+
+
 class LookupCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         try:
-            self.cty = BigCty("./data/cty.json")
+            self.cty = BigCty(cty_path)
         except OSError:
             self.cty = BigCty()
 
@@ -67,7 +71,7 @@ class LookupCog(commands.Cog):
 
     @tasks.loop(hours=24)
     async def _update_cty(self):
-        update = threading.Thread(target=run_update, args=(self.cty, "./data/cty.json"))
+        update = threading.Thread(target=run_update, args=(self.cty, cty_path))
         update.start()
 
 


### PR DESCRIPTION
Turns out most paths were already using pathlib, only remained
some in lookup.py and fun.py

Fixes #45

- [x] Issue exists for PR
- [x] Code reviewed by the author
- [x] Code documented (comments or other documentation)
- [x] Changes tested
- [x] All tests pass (see [`DEVELOPING.md`][0], if it exists)
- [x] [`CHANGELOG.md`][1] updated if needed
- [x] Informative commit messages
- [x] Descriptive PR title

[0]: /DEVELOPING.md
[1]: /CHANGELOG.md
