### PR TITLE
Validate inputs for ?ae7q and ?qrz commands

### DIFF
--- a/exts/ae7q.py
+++ b/exts/ae7q.py
@@ -16,6 +16,8 @@ the GNU General Public License, version 2.
 # KC4USA: reserved, no call history, *but* has application history
 
 
+import re
+
 import aiohttp
 from bs4 import BeautifulSoup
 
@@ -43,6 +45,14 @@ class AE7QCog(commands.Cog):
             desc = ""
             base_url = "http://ae7q.com/query/data/CallHistory.php?CALL="
             embed = cmn.embed_factory(ctx)
+
+            if not re.match('[A-Z0-9]+$', callsign):
+                embed = cmn.embed_factory(ctx)
+                embed.title = "AE7Q History for Callsign"
+                embed.colour = cmn.colours.bad
+                embed.description = "Not a valid callsign!"
+                await ctx.send(embed=embed)
+                return
 
             async with self.session.get(base_url + callsign) as resp:
                 if resp.status != 200:
@@ -109,6 +119,14 @@ class AE7QCog(commands.Cog):
             desc = ""
             base_url = "http://ae7q.com/query/data/CallHistory.php?CALL="
             embed = cmn.embed_factory(ctx)
+
+            if not re.match('[A-Z0-9]+$', callsign):
+                embed = cmn.embed_factory(ctx)
+                embed.title = "AE7Q Trustee History for Callsign"
+                embed.colour = cmn.colours.bad
+                embed.description = "Not a valid callsign!"
+                await ctx.send(embed=embed)
+                return
 
             async with self.session.get(base_url + callsign) as resp:
                 if resp.status != 200:
@@ -177,6 +195,14 @@ class AE7QCog(commands.Cog):
             desc = ""
             base_url = "http://ae7q.com/query/data/CallHistory.php?CALL="
             embed = cmn.embed_factory(ctx)
+
+            if not re.match('[A-Z0-9]+$', callsign):
+                embed = cmn.embed_factory(ctx)
+                embed.title = "AE7Q Application History for Callsign"
+                embed.colour = cmn.colours.bad
+                embed.description = "Not a valid callsign!"
+                await ctx.send(embed=embed)
+                return
 
             async with self.session.get(base_url + callsign) as resp:
                 if resp.status != 200:
@@ -250,6 +276,14 @@ class AE7QCog(commands.Cog):
             base_url = "http://ae7q.com/query/data/FrnHistory.php?FRN="
             embed = cmn.embed_factory(ctx)
 
+            if not re.match('[0-9]+$', frn):
+                embed = cmn.embed_factory(ctx)
+                embed.title = "AE7Q History for FRN"
+                embed.colour = cmn.colours.bad
+                embed.description = "Not a valid FRN!"
+                await ctx.send(embed=embed)
+                return
+
             async with self.session.get(base_url + frn) as resp:
                 if resp.status != 200:
                     raise cmn.BotHTTPError(resp)
@@ -312,6 +346,14 @@ class AE7QCog(commands.Cog):
             licensee_id = licensee_id.upper()
             base_url = "http://ae7q.com/query/data/LicenseeIdHistory.php?ID="
             embed = cmn.embed_factory(ctx)
+
+            if not re.match('[A-Z][0-9]+$', licensee_id, re.IGNORECASE):
+                embed = cmn.embed_factory(ctx)
+                embed.title = "AE7Q History for Licensee"
+                embed.colour = cmn.colours.bad
+                embed.description = "Not a valid licensee ID!"
+                await ctx.send(embed=embed)
+                return
 
             async with self.session.get(base_url + licensee_id) as resp:
                 if resp.status != 200:

--- a/exts/ae7q.py
+++ b/exts/ae7q.py
@@ -16,8 +16,6 @@ the GNU General Public License, version 2.
 # KC4USA: reserved, no call history, *but* has application history
 
 
-import re
-
 import aiohttp
 from bs4 import BeautifulSoup
 
@@ -46,7 +44,7 @@ class AE7QCog(commands.Cog):
             base_url = "http://ae7q.com/query/data/CallHistory.php?CALL="
             embed = cmn.embed_factory(ctx)
 
-            if not re.match('[A-Z0-9]+$', callsign):
+            if not callsign.isalnum():
                 embed = cmn.embed_factory(ctx)
                 embed.title = "AE7Q History for Callsign"
                 embed.colour = cmn.colours.bad
@@ -120,7 +118,7 @@ class AE7QCog(commands.Cog):
             base_url = "http://ae7q.com/query/data/CallHistory.php?CALL="
             embed = cmn.embed_factory(ctx)
 
-            if not re.match('[A-Z0-9]+$', callsign):
+            if not callsign.isalnum():
                 embed = cmn.embed_factory(ctx)
                 embed.title = "AE7Q Trustee History for Callsign"
                 embed.colour = cmn.colours.bad
@@ -196,7 +194,7 @@ class AE7QCog(commands.Cog):
             base_url = "http://ae7q.com/query/data/CallHistory.php?CALL="
             embed = cmn.embed_factory(ctx)
 
-            if not re.match('[A-Z0-9]+$', callsign):
+            if not callsign.isalnum():
                 embed = cmn.embed_factory(ctx)
                 embed.title = "AE7Q Application History for Callsign"
                 embed.colour = cmn.colours.bad
@@ -276,7 +274,7 @@ class AE7QCog(commands.Cog):
             base_url = "http://ae7q.com/query/data/FrnHistory.php?FRN="
             embed = cmn.embed_factory(ctx)
 
-            if not re.match('[0-9]+$', frn):
+            if not frn.isdecimal():
                 embed = cmn.embed_factory(ctx)
                 embed.title = "AE7Q History for FRN"
                 embed.colour = cmn.colours.bad
@@ -347,7 +345,7 @@ class AE7QCog(commands.Cog):
             base_url = "http://ae7q.com/query/data/LicenseeIdHistory.php?ID="
             embed = cmn.embed_factory(ctx)
 
-            if not re.match('[A-Z][0-9]+$', licensee_id, re.IGNORECASE):
+            if not licensee_id.isalnum():
                 embed = cmn.embed_factory(ctx)
                 embed.title = "AE7Q History for Licensee"
                 embed.colour = cmn.colours.bad

--- a/exts/qrz.py
+++ b/exts/qrz.py
@@ -9,7 +9,6 @@ the GNU General Public License, version 2.
 
 
 from io import BytesIO
-import re
 
 import aiohttp
 from lxml import etree
@@ -32,7 +31,7 @@ class QRZCog(commands.Cog):
         """Looks up a callsign on [QRZ.com](https://www.qrz.com/). Add `--link` to only link the QRZ page."""
         flags = [f.lower() for f in flags]
 
-        if not re.match('[A-Z0-9]+$', callsign, re.IGNORECASE):
+        if not callsign.isalnum():
             embed = cmn.embed_factory(ctx)
             embed.title = "QRZ Data for Callsign"
             embed.colour = cmn.colours.bad

--- a/exts/qrz.py
+++ b/exts/qrz.py
@@ -9,6 +9,7 @@ the GNU General Public License, version 2.
 
 
 from io import BytesIO
+import re
 
 import aiohttp
 from lxml import etree
@@ -30,6 +31,14 @@ class QRZCog(commands.Cog):
     async def _qrz_lookup(self, ctx: commands.Context, callsign: str, *flags):
         """Looks up a callsign on [QRZ.com](https://www.qrz.com/). Add `--link` to only link the QRZ page."""
         flags = [f.lower() for f in flags]
+
+        if not re.match('[A-Z0-9]+$', callsign, re.IGNORECASE):
+            embed = cmn.embed_factory(ctx)
+            embed.title = "QRZ Data for Callsign"
+            embed.colour = cmn.colours.bad
+            embed.description = "Not a valid callsign!"
+            await ctx.send(embed=embed)
+            return
 
         if keys.qrz_user == "" or keys.qrz_pass == "" or "--link" in flags:
             await ctx.send(f"http://qrz.com/db/{callsign}")


### PR DESCRIPTION
### Description

I added input validation to the ?ae7q and ?qrz commands (callsigns, FRNs, and license IDs). This is very basic validation, just confirming that the input is alphanumeric/numeric, since it's getting passed into URLs.

Fixes #345

### Type of change

- New feature <!-- non-breaking change which adds functionality -->

### How has this been tested?

Tested the commands using my own instance of the bot.

### Checklist

- [X] Issue exists for PR
- [X] Code reviewed by the author
- [X] Code documented (comments or other documentation)
- [X] Changes tested
- [X] All tests pass (see [`DEVELOPING.md`][0], if it exists)
- [ ] [`CHANGELOG.md`][1] updated if needed
- [X] Informative commit messages
- [X] Descriptive PR title

[0]: /DEVELOPING.md
[1]: /CHANGELOG.md
