### PR TITLE
fix function signature of filter_commands() to ignore other args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - a new way to support qrm's development.
 ### Changed
-- Changed the licence to LiLiQ-Rplus-1.1
+- Changed the licence to LiLiQ-Rplus-1.1.
+### Fixed
+- Issue where the help command errored.
 
 
 ## [2.7.3] - 2021-04-12

--- a/exts/base.py
+++ b/exts/base.py
@@ -31,7 +31,7 @@ class QrmHelpCommand(commands.HelpCommand):
         self.verify_checks = True
         self.context: commands.Context
 
-    async def filter_commands(self, commands: Iterable[Command]) -> list[Command]:
+    async def filter_commands(self, commands: Iterable[Command], **kwargs) -> list[Command]:
         def sort_by_cat(cmds):
             ret = []
             bolt_cmds = {}


### PR DESCRIPTION
discord.py changed the signature to add kwargs which are not used by
qrm's help command

fixes #432