### PR TITLE
Add NOAA D-RAP map to propagation plugin ?drapmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]
+### Added
+- `?drapmap` command to display NOAA D Region Absorption Predictions map.
 
 
 ## [2.9.1] - 2023-01-29

--- a/exts/propagation.py
+++ b/exts/propagation.py
@@ -24,6 +24,7 @@ class PropagationCog(commands.Cog):
     fof2_url = "https://prop.kc2g.com/renders/current/fof2-normal-now.svg"
     gl_baseurl = "https://www.fourmilab.ch/cgi-bin/uncgi/Earth?img=ETOPO1_day-m.evif&dynimg=y&opt=-p"
     n0nbh_sun_url = "http://www.hamqsl.com/solarsun.php"
+    noaa_drap_url = "https://services.swpc.noaa.gov/images/animations/d-rap/global/d-rap/latest.png"
 
     def __init__(self, bot):
         self.bot = bot
@@ -85,6 +86,17 @@ class PropagationCog(commands.Cog):
         embed.colour = cmn.colours.good
         embed.set_image(url="attachment://solarweather.png")
         await ctx.send(file=file, embed=embed)
+
+    @commands.command(name="drapmap", aliases=["drap"], category=cmn.Cats.WEATHER)
+    async def drapmap(self, ctx: commands.Context):
+        """Gets the current D-RAP map for radio blackouts"""
+        embed = cmn.embed_factory(ctx)
+        embed.title = "D Region Absorption Predictions (D-RAP) Map"
+        embed.colour = cmn.colours.good
+        embed.description = \
+            "Image from [swpc.noaa.gov](https://www.swpc.noaa.gov/products/d-region-absorption-predictions-d-rap)"
+        embed.set_image(url=self.noaa_drap_url)
+        await ctx.send(embed=embed)
 
 
 def setup(bot: commands.Bot):


### PR DESCRIPTION
### Description

Added a command to display the current NOAA D-RAP map (https://www.swpc.noaa.gov/products/d-region-absorption-predictions-d-rap)

Fixes 
N/A

### Type of change

- New feature 

### How has this been tested?

Bot was created on Discord, and added to a dev server. Commands were run:
?drapmap
?drap
?solarweather (this is failing in both current master and this branch)
flake8 run

### Checklist

- [ ] Issue exists for PR
- [x] Code reviewed by the author
- [x] Code documented (comments or other documentation)
- [x] Changes tested
- [x] All tests pass (see [`DEVELOPING.md`][0], if it exists)
- [x] [`CHANGELOG.md`][1] updated if needed
- [x] Informative commit messages
- [x] Descriptive PR title

[0]: /DEVELOPING.md
[1]: /CHANGELOG.md
