### PR TITLE
.github/workflows/release.yml: move to ncipollo/create-release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,12 +48,10 @@ jobs:
 
       - name: Publish Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ env.tag_version }}
-          release_name: ${{ env.tag_subject }}
+          tag: ${{ env.tag_version }}
+          name: ${{ env.tag_subject }}
           body: |
             ${{ env.tag_body }}
 


### PR DESCRIPTION
fixes #464

see:

- https://github.com/classabbyamp/qrm2/releases/tag/v3.0.0
- https://github.com/classabbyamp/qrm2/actions/runs/3913645055
