### PR TITLE
Embed factory/pycord fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]
+### Fixed
+- Issue where embeds would not work for users without avatars (#467).
 
 
 ## [2.9.0] - 2023-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 - Issue where embeds would not work for users without avatars (#467).
+- Issue where embeds would show the wrong timezone.
 
 
 ## [2.9.0] - 2023-01-13

--- a/common.py
+++ b/common.py
@@ -167,7 +167,7 @@ def embed_factory(ctx: commands.Context) -> discord.Embed:
     """Creates an embed with neutral colour and standard footer."""
     embed = discord.Embed(timestamp=datetime.utcnow(), colour=colours.neutral)
     if ctx.author:
-        embed.set_footer(text=str(ctx.author), icon_url=str(ctx.author.avatar.url))
+        embed.set_footer(text=str(ctx.author), icon_url=str(ctx.author.display_avatar))
     return embed
 
 

--- a/common.py
+++ b/common.py
@@ -12,7 +12,7 @@ import enum
 import json
 import re
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Union
@@ -165,7 +165,7 @@ class GlobalChannelConverter(commands.IDConverter):
 
 def embed_factory(ctx: commands.Context) -> discord.Embed:
     """Creates an embed with neutral colour and standard footer."""
-    embed = discord.Embed(timestamp=datetime.utcnow(), colour=colours.neutral)
+    embed = discord.Embed(timestamp=datetime.now(timezone.utc), colour=colours.neutral)
     if ctx.author:
         embed.set_footer(text=str(ctx.author), icon_url=str(ctx.author.display_avatar))
     return embed


### PR DESCRIPTION
- common.py: don't error when creating embeds for users without avatars
    - behaviour changed in pycord 2.0: https://docs.pycord.dev/en/stable/api/models.html#discord.User.display_avatar
- common.py: use tz-aware datetime for proper timestamp display
    - https://docs.pycord.dev/en/stable/api/data_classes.html#discord.Embed.timestamp

fixes #467
