### PR TITLE
escape Markdown bullets in morse conversion/deconversion output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix indentation in some text responses.
 ### Removed
 - Deprecated `ae7q` extension from the default configuration (#486).
+### Fixed
+- Issue where ?morse/?demorse outputs beginning with `-` rendered as a bulleted list (#484).
 
 
 ## [2.9.2] - 2023-12-15

--- a/exts/morse.py
+++ b/exts/morse.py
@@ -34,7 +34,7 @@ class MorseCog(commands.Cog):
             result += " "
         embed = cmn.embed_factory(ctx)
         embed.title = f"Morse Code for {msg}"
-        embed.description = "**" + result + "**"
+        embed.description = "**`" + result + "`**"
         embed.colour = cmn.colours.good
         await ctx.send(embed=embed)
 
@@ -54,7 +54,7 @@ class MorseCog(commands.Cog):
             result += " "
         embed = cmn.embed_factory(ctx)
         embed.title = f"ASCII for {msg0}"
-        embed.description = result
+        embed.description = "`" + result + "`"
         embed.colour = cmn.colours.good
         await ctx.send(embed=embed)
 


### PR DESCRIPTION
### Description

render morse conversion output in fixed width, and escape Markdown bullets at the start of morse deconversion

Fixes #484 

### Type of change

- Bug fix

### How has this been tested?

Tested string manipulation in a local Python instance. I currently have no way to test the generation of Discord embeds.

### Checklist

- [x] Issue exists for PR
- [ ] Code reviewed by the author
- [ ] Code documented (comments or other documentation)
- [ ] Changes tested
- [ ] All tests pass (see [`DEVELOPING.md`][0], if it exists)
- [x] [`CHANGELOG.md`][1] updated if needed
- [x] Informative commit messages
- [x] Descriptive PR title

[0]: /DEVELOPING.md
[1]: /CHANGELOG.md
