### PR TITLE
Remove deprecated ae7q extension from options.py template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `run.sh` to respect the `VIRTUAL_ENV` environment variable.
 - Use Discord application emojis.
 - Fix indentation in some text responses.
+### Removed
+- Deprecated `ae7q` extension from the default configuration (#486).
 
 
 ## [2.9.2] - 2023-12-15

--- a/templates/data/options.py
+++ b/templates/data/options.py
@@ -35,7 +35,6 @@ owners_uids = (200102491231092736, 564766093051166729)
 # The extensions to load when running the bot.
 exts = [
     "base",
-    "ae7q",
     "callsign",
     "codes",
     "contests",


### PR DESCRIPTION
### Description

There's no point in loading this for new installs since it's deprecated. Perhaps it'll be removed entirely in the future.

### Type of change

<!-- Please delete options that are not relevant. -->

- Refactor/code cleanup <!-- non-breaking change which does not add functionality or fix an issue -->